### PR TITLE
Changed the statically initialized Subsystems to dynamic initialization

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -29,7 +29,7 @@
 								<option id="gnu.cpp.compiler.option.debugging.level.969129918" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
 								<option id="gnu.cpp.compiler.option.include.paths.394786621" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${WPILIB}/cpp/current/include&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/GearsBotByHandC/src&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/GearsBotByHandC/src/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${WPILIB}/user/cpp/include&quot;"/>
 								</option>
 								<option id="gnu.cpp.compiler.option.dialect.std.1060340803" name="Language standard" superClass="gnu.cpp.compiler.option.dialect.std" useByScannerDiscovery="true" value="gnu.cpp.compiler.dialect.c++1y" valueType="enumerated"/>
@@ -81,20 +81,20 @@
 							<builder buildPath="${workspace_loc}/GearsBotByHandC/Simulate" errorParsers="org.eclipse.cdt.core.GmakeErrorParser;org.eclipse.cdt.core.CWDLocator" id="cdt.managedbuild.target.gnu.builder.base.840272037" keepEnvironmentInBuildfile="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.base"/>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.base.158466008" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.base"/>
 							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.base.2105416021" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.base">
-								<option id="gnu.cpp.compiler.option.include.paths.1645322059" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" valueType="includePath">
+								<option id="gnu.cpp.compiler.option.include.paths.1645322059" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc}/GearsBotByHandC/src&quot;"/>
 									<listOptionValue builtIn="false" value="${WPILIB}/cpp/current/sim/include"/>
 									<listOptionValue builtIn="false" value="/usr/include"/>
 									<listOptionValue builtIn="false" value="/usr/include/gazebo-5.0"/>
 									<listOptionValue builtIn="false" value="/usr/include/sdformat-2.3"/>
 								</option>
-								<option id="gnu.cpp.compiler.option.optimization.level.1648211502" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
-								<option id="gnu.cpp.compiler.option.debugging.level.937474733" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.optimization.level.1648211502" name="Optimization Level" superClass="gnu.cpp.compiler.option.optimization.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.optimization.level.none" valueType="enumerated"/>
+								<option id="gnu.cpp.compiler.option.debugging.level.937474733" name="Debug Level" superClass="gnu.cpp.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.cpp.compiler.debugging.level.max" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1758810658" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.c.compiler.base.2039239712" name="GCC C Compiler" superClass="cdt.managedbuild.tool.gnu.c.compiler.base">
-								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.2100353684" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" valueType="enumerated"/>
-								<option id="gnu.c.compiler.option.debugging.level.1900634657" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" value="gnu.c.debugging.level.max" valueType="enumerated"/>
+								<option defaultValue="gnu.c.optimization.level.none" id="gnu.c.compiler.option.optimization.level.2100353684" name="Optimization Level" superClass="gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" valueType="enumerated"/>
+								<option id="gnu.c.compiler.option.debugging.level.1900634657" name="Debug Level" superClass="gnu.c.compiler.option.debugging.level" useByScannerDiscovery="false" value="gnu.c.debugging.level.max" valueType="enumerated"/>
 								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.1197133064" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.c.linker.base.66697269" name="GCC C Linker" superClass="cdt.managedbuild.tool.gnu.c.linker.base"/>
@@ -150,4 +150,5 @@
 			<resource resourceType="PROJECT" workspacePath="/GearsBotByHandC"/>
 		</configuration>
 	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets"/>
 </cproject>

--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -16,7 +16,7 @@
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-1598604866576319918" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-1598143691034105918" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/.settings/org.eclipse.cdt.managedbuilder.core.prefs
+++ b/.settings/org.eclipse.cdt.managedbuilder.core.prefs
@@ -1,4 +1,12 @@
 eclipse.preferences.version=1
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/CPATH/delimiter=\:
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/CPATH/operation=remove
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/CPLUS_INCLUDE_PATH/delimiter=\:
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/CPLUS_INCLUDE_PATH/operation=remove
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/C_INCLUDE_PATH/delimiter=\:
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/C_INCLUDE_PATH/operation=remove
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/append=true
+environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/appendContributed=true
 environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/CPATH/delimiter=\:
 environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/CPATH/operation=remove
 environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/CPLUS_INCLUDE_PATH/delimiter=\:
@@ -7,6 +15,10 @@ environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.
 environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/C_INCLUDE_PATH/operation=remove
 environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/append=true
 environment/buildEnvironmentInclude/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/appendContributed=true
+environment/buildEnvironmentLibrary/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/LIBRARY_PATH/delimiter=\:
+environment/buildEnvironmentLibrary/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/LIBRARY_PATH/operation=remove
+environment/buildEnvironmentLibrary/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/append=true
+environment/buildEnvironmentLibrary/cdt.managedbuild.config.gnu.cross.exe.debug.1104744751/appendContributed=true
 environment/buildEnvironmentLibrary/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/LIBRARY_PATH/delimiter=\:
 environment/buildEnvironmentLibrary/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/LIBRARY_PATH/operation=remove
 environment/buildEnvironmentLibrary/cdt.managedbuild.config.gnu.cross.exe.debug.418253318/append=true

--- a/src/cpp/Commands/CloseGripper.cpp
+++ b/src/cpp/Commands/CloseGripper.cpp
@@ -6,14 +6,12 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Commands/CloseGripper.h"
-
 #include "Robot.h"
 
 CloseGripper::CloseGripper() : frc::TimedCommand(1) {
-  // FIXME: Add reference overload of Requires()
-  Requires(&Robot::gripper);
+  Requires(Robot::gripper);
 }
 
-void CloseGripper::Initialize() { Robot::gripper.Close(); }
+void CloseGripper::Initialize() { Robot::gripper->Close(); }
 
-void CloseGripper::End() { Robot::gripper.Stop(); }
+void CloseGripper::End() { Robot::gripper->Stop(); }

--- a/src/cpp/Commands/CloseGripper.cpp
+++ b/src/cpp/Commands/CloseGripper.cpp
@@ -9,7 +9,7 @@
 #include "Robot.h"
 
 CloseGripper::CloseGripper() : frc::TimedCommand(1) {
-  Requires(Robot::gripper);
+  Requires(Robot::gripper.get());
 }
 
 void CloseGripper::Initialize() { Robot::gripper->Close(); }

--- a/src/cpp/Commands/DefaultDrive.cpp
+++ b/src/cpp/Commands/DefaultDrive.cpp
@@ -10,7 +10,7 @@
 #include "Robot.h"
 
 DefaultDrive::DefaultDrive() {
-  Requires(Robot::driveBase);
+  Requires(Robot::driveBase.get());
 }
 
 void DefaultDrive::Execute() { Robot::driveBase->DriveWithJoystick(); }

--- a/src/cpp/Commands/DefaultDrive.cpp
+++ b/src/cpp/Commands/DefaultDrive.cpp
@@ -10,10 +10,9 @@
 #include "Robot.h"
 
 DefaultDrive::DefaultDrive() {
-  // FIXME: Add reference overload of Requires()
-  Requires(&Robot::driveBase);
+  Requires(Robot::driveBase);
 }
 
-void DefaultDrive::Execute() { Robot::driveBase.DriveWithJoystick(); }
+void DefaultDrive::Execute() { Robot::driveBase->DriveWithJoystick(); }
 
 bool DefaultDrive::IsFinished() { return false; }

--- a/src/cpp/Commands/DriveAway.cpp
+++ b/src/cpp/Commands/DriveAway.cpp
@@ -6,14 +6,12 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Commands/DriveAway.h"
-
 #include "Robot.h"
 
 DriveAway::DriveAway() : frc::TimedCommand(1) {
-  // FIXME: Add reference overload of Requires()
-  Requires(&Robot::driveBase);
+  Requires(Robot::driveBase);
 }
 
-void DriveAway::Initialize() { Robot::driveBase.Backwards(); }
+void DriveAway::Initialize() { Robot::driveBase->Backwards(); }
 
-void DriveAway::End() { Robot::driveBase.Stop(); }
+void DriveAway::End() { Robot::driveBase->Stop(); }

--- a/src/cpp/Commands/DriveAway.cpp
+++ b/src/cpp/Commands/DriveAway.cpp
@@ -9,7 +9,7 @@
 #include "Robot.h"
 
 DriveAway::DriveAway() : frc::TimedCommand(1) {
-  Requires(Robot::driveBase);
+  Requires(Robot::driveBase.get());
 }
 
 void DriveAway::Initialize() { Robot::driveBase->Backwards(); }

--- a/src/cpp/Commands/DriveForward.cpp
+++ b/src/cpp/Commands/DriveForward.cpp
@@ -10,10 +10,9 @@
 #include "Robot.h"
 
 DriveForward::DriveForward() : frc::TimedCommand(1) {
-  // FIXME: Add reference overload of Requires()
-  Requires(&Robot::driveBase);
+  Requires(Robot::driveBase);
 }
 
-void DriveForward::Initialize() { Robot::driveBase.Forwards(); }
+void DriveForward::Initialize() { Robot::driveBase->Forwards(); }
 
-void DriveForward::End() { Robot::driveBase.Stop(); }
+void DriveForward::End() { Robot::driveBase->Stop(); }

--- a/src/cpp/Commands/DriveForward.cpp
+++ b/src/cpp/Commands/DriveForward.cpp
@@ -10,7 +10,7 @@
 #include "Robot.h"
 
 DriveForward::DriveForward() : frc::TimedCommand(1) {
-  Requires(Robot::driveBase);
+  Requires(Robot::driveBase.get());
 }
 
 void DriveForward::Initialize() { Robot::driveBase->Forwards(); }

--- a/src/cpp/Commands/ElevatorMove.cpp
+++ b/src/cpp/Commands/ElevatorMove.cpp
@@ -6,18 +6,16 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Commands/ElevatorMove.h"
-
 #include "Robot.h"
 
 ElevatorMove::ElevatorMove(double setpoint) {
   m_setpoint = setpoint;
-  // FIXME: Add reference overload of Requires()
-  Requires(&Robot::elevator);
+  Requires(Robot::elevator);
 }
 
 void ElevatorMove::Initialize() {
-  Robot::elevator.Enable();
-  Robot::elevator.SetSetpoint(m_setpoint);
+  Robot::elevator->Enable();
+  Robot::elevator->SetSetpoint(m_setpoint);
 }
 
-bool ElevatorMove::IsFinished() { return Robot::elevator.OnTarget(); }
+bool ElevatorMove::IsFinished() { return Robot::elevator->OnTarget(); }

--- a/src/cpp/Commands/ElevatorMove.cpp
+++ b/src/cpp/Commands/ElevatorMove.cpp
@@ -10,7 +10,7 @@
 
 ElevatorMove::ElevatorMove(double setpoint) {
   m_setpoint = setpoint;
-  Requires(Robot::elevator);
+  Requires(Robot::elevator.get());
 }
 
 void ElevatorMove::Initialize() {

--- a/src/cpp/Commands/OpenGripper.cpp
+++ b/src/cpp/Commands/OpenGripper.cpp
@@ -10,7 +10,7 @@
 #include "Robot.h"
 
 OpenGripper::OpenGripper() : frc::TimedCommand(1) {
-  Requires(Robot::gripper);
+  Requires(Robot::gripper.get());
 }
 
 void OpenGripper::Initialize() { Robot::gripper->Open(); }

--- a/src/cpp/Commands/OpenGripper.cpp
+++ b/src/cpp/Commands/OpenGripper.cpp
@@ -10,9 +10,8 @@
 #include "Robot.h"
 
 OpenGripper::OpenGripper() : frc::TimedCommand(1) {
-  // FIXME: Add reference overload of Requires()
-  Requires(&Robot::gripper);
+  Requires(Robot::gripper);
 }
 
-void OpenGripper::Initialize() { Robot::gripper.Open(); }
-void OpenGripper::End() { Robot::gripper.Close(); }
+void OpenGripper::Initialize() { Robot::gripper->Open(); }
+void OpenGripper::End() { Robot::gripper->Close(); }

--- a/src/cpp/Commands/WristMove.cpp
+++ b/src/cpp/Commands/WristMove.cpp
@@ -10,7 +10,7 @@
 
 WristMove::WristMove(double setpoint) {
   m_setpoint = setpoint;
-  Requires(Robot::wrist);
+  Requires(Robot::wrist.get());
 }
 
 void WristMove::Initialize() {

--- a/src/cpp/Commands/WristMove.cpp
+++ b/src/cpp/Commands/WristMove.cpp
@@ -6,18 +6,16 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Commands/WristMove.h"
-
 #include "Robot.h"
 
 WristMove::WristMove(double setpoint) {
   m_setpoint = setpoint;
-  // FIXME: Add reference overload of Requires()
-  Requires(&Robot::wrist);
+  Requires(Robot::wrist);
 }
 
 void WristMove::Initialize() {
-  Robot::wrist.Enable();
-  Robot::wrist.SetSetpoint(m_setpoint);
+  Robot::wrist->Enable();
+  Robot::wrist->SetSetpoint(m_setpoint);
 }
 
-bool WristMove::IsFinished() { return Robot::wrist.OnTarget(); }
+bool WristMove::IsFinished() { return Robot::wrist->OnTarget(); }

--- a/src/cpp/Robot.cpp
+++ b/src/cpp/Robot.cpp
@@ -10,13 +10,13 @@
 #include <Commands/Scheduler.h>
 #include <SmartDashboard/SmartDashboard.h>
 
-OI Robot::oi;
-DriveBase Robot::driveBase;
-Gripper Robot::gripper;
-Wrist Robot::wrist;
-Elevator Robot::elevator;
-
 void Robot::RobotInit() {
+	Robot::oi = new OI();
+	Robot::driveBase = new DriveBase();
+	Robot::gripper = new Gripper();
+	Robot::wrist = new Wrist();
+	Robot::elevator = new Elevator();
+
   // FIXME: Add reference overload of frc::SendableChooser::AddDefault()
   m_chooser.AddDefault("Everything", &m_autonomousCommand);
   // FIXME: Add reference overload of frc::SmartDashboard::PutData()

--- a/src/cpp/Robot.cpp
+++ b/src/cpp/Robot.cpp
@@ -10,6 +10,12 @@
 #include <Commands/Scheduler.h>
 #include <SmartDashboard/SmartDashboard.h>
 
+OI * Robot::oi = NULL;
+Gripper * Robot::gripper = NULL;
+DriveBase * Robot::driveBase = NULL;
+Elevator * Robot::elevator = NULL;
+Wrist * Robot::wrist = NULL;
+
 void Robot::RobotInit() {
 	Robot::oi = new OI();
 	Robot::driveBase = new DriveBase();

--- a/src/cpp/Robot.cpp
+++ b/src/cpp/Robot.cpp
@@ -10,18 +10,18 @@
 #include <Commands/Scheduler.h>
 #include <SmartDashboard/SmartDashboard.h>
 
-OI * Robot::oi = NULL;
-Gripper * Robot::gripper = NULL;
-DriveBase * Robot::driveBase = NULL;
-Elevator * Robot::elevator = NULL;
-Wrist * Robot::wrist = NULL;
+std::unique_ptr<OI> Robot::oi;
+std::unique_ptr<Gripper> Robot::gripper;
+std::unique_ptr<DriveBase> Robot::driveBase;
+std::unique_ptr<Elevator> Robot::elevator;
+std::unique_ptr<Wrist> Robot::wrist;
 
 void Robot::RobotInit() {
-	Robot::oi = new OI();
-	Robot::driveBase = new DriveBase();
-	Robot::gripper = new Gripper();
-	Robot::wrist = new Wrist();
-	Robot::elevator = new Elevator();
+	Robot::oi = std::make_unique<OI>();
+	Robot::driveBase = std::make_unique<DriveBase>();
+	Robot::gripper = std::make_unique<Gripper>();
+	Robot::wrist = std::make_unique<Wrist>();
+	Robot::elevator = std::make_unique<Elevator>();
 
   // FIXME: Add reference overload of frc::SendableChooser::AddDefault()
   m_chooser.AddDefault("Everything", &m_autonomousCommand);

--- a/src/cpp/Subsystems/DriveBase.cpp
+++ b/src/cpp/Subsystems/DriveBase.cpp
@@ -6,7 +6,6 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Subsystems/DriveBase.h"
-
 #include <ctre/Phoenix.h>
 
 #include "Robot.h"
@@ -21,7 +20,7 @@ void DriveBase::InitDefaultCommand() {}
 void DriveBase::Periodic() {}
 
 void DriveBase::DriveWithJoystick() {
-  auto& stick = Robot::oi.GetStick();
+  auto& stick = Robot::oi->GetStick();
   m_differentialDrive.ArcadeDrive(-stick.GetY(), -stick.GetX());
 }
 

--- a/src/cpp/Subsystems/Gripper.cpp
+++ b/src/cpp/Subsystems/Gripper.cpp
@@ -6,6 +6,7 @@
 /*----------------------------------------------------------------------------*/
 
 #include "Subsystems/Gripper.h"
+
 #include <Victor.h>
 
 Gripper::Gripper() : frc::Subsystem("Gripper") {

--- a/src/include/Robot.h
+++ b/src/include/Robot.h
@@ -20,11 +20,11 @@
 
 class Robot : public frc::TimedRobot {
  public:
-  static OI oi;
-  static DriveBase driveBase;
-  static Gripper gripper;
-  static Wrist wrist;
-  static Elevator elevator;
+  static OI * oi;
+  static DriveBase * driveBase;
+  static Gripper * gripper;
+  static Wrist * wrist;
+  static Elevator * elevator;
 
   void RobotInit() override;
   void DisabledInit() override;

--- a/src/include/Robot.h
+++ b/src/include/Robot.h
@@ -20,11 +20,11 @@
 
 class Robot : public frc::TimedRobot {
  public:
-  static OI * oi;
-  static DriveBase * driveBase;
-  static Gripper * gripper;
-  static Wrist * wrist;
-  static Elevator * elevator;
+  static std::unique_ptr<OI> oi;
+  static std::unique_ptr<DriveBase> driveBase;
+  static std::unique_ptr<Gripper> gripper;
+  static std::unique_ptr<Wrist> wrist;
+  static std::unique_ptr<Elevator> elevator;
 
   void RobotInit() override;
   void DisabledInit() override;


### PR DESCRIPTION
Doing static creation of the subsystems will cause their constructors to run, potentially, before anything else in the library and could cause issues. There is no way to guarantee the order of static construction, so the safest way to do this is to make they dynamically allocated.